### PR TITLE
6.07

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -2,10 +2,10 @@ require 'formula'
 
 class Csound < Formula
   homepage 'http://csound.github.io'
-  url 'http://sourceforge.net/projects/csound/files/csound6/Csound6.05/Csound6.05.tar.gz/download'
-  sha1 '9bda2ba4adc5b869caca470be6d82bf2ed3f5309'
+  url 'https://github.com/csound/csound/archive/6.07.0.tar.gz'
+  sha256 '606af463da477cf4a3f89d00a4fda63c7eb0dc7f50a8923069f009dfdc545799'
   head 'https://github.com/csound/csound.git', :branch => 'develop'
-  version '6.05.0'
+  version '6.07.0'
 
   depends_on 'cmake' => :build
   depends_on 'swig' => :build
@@ -18,17 +18,16 @@ class Csound < Formula
   depends_on 'boost' => :recommended
   depends_on 'libpng' => :recommended
   depends_on 'stk' => :optional
-  depends_on 'fltk' => :recommended
+  depends_on 'fltk' => :optional
   depends_on 'eigen' => :recommended
 
   option :universal
 
   def install
-    if build.with? "stk"
-      system "cmake", ".", "-DUSE_GETTEXT=0", "-DBUILD_STK_OPCODES=1", *std_cmake_args
-    else
-      system "cmake", ".", "-DUSE_GETTEXT=0", "-DBUILD_STK_OPCODES=0", *std_cmake_args
-    end
+    framework = "#{prefix}/Framework"
+    inreplace "CMakeLists.txt", "~/Library/Frameworks", framework
+    stk = (build.with? "stk") ? 1 : 0
+    system "cmake", ".", "-DUSE_GETTEXT=0", "-DBUILD_STK_OPCODES=#{stk}", "-DCMAKE_MACOSX_RPATH=ON", "-DCMAKE_INSTALL_RPATH=#{framework}", *std_cmake_args
     system "make", "install"
   end
 


### PR DESCRIPTION
This PR:
* updates Csound to 6.07
* sets fltk dependency (which seems to be broken)  to optional (see #13)
* fixes #12
* fixes the "Could not fix CsoundLib64.framework/Versions/6.0/CsoundLib64" warnings

Inspired by https://github.com/csound/csound/pull/584, but applies the changes to the homebrew formula instead of Csound's CMakeLists.txt.